### PR TITLE
Fixed a couple of typos in code snippets

### DIFF
--- a/v4.x/fsharp/ui.md
+++ b/v4.x/fsharp/ui.md
@@ -389,7 +389,7 @@ You can also declare a template from multiple files at once using a comma-separa
 
 open WebSharper.UI.Templating
 
-type MyTemplate = Template<"my-template.html">
+type MyTemplate = Template<"my-template.html, second-template.html">
 
 let myPage =
     Doc.Concat [
@@ -1603,7 +1603,7 @@ let GetContactDetails p = async { ... }
 let ContactMain() =    
     let location = // ...
     let contactDetails = location.View |> View.MapAsync GetContactDetails
-    contactDetails.View.Doc(fun p -> 
+    contactDetails.Doc(fun p -> 
         // show contact details
     )
 ```


### PR DESCRIPTION
1 - example snippet of usage one template for multiple files
2 - example snippet of usage client-side routing and RPC call (tried this example by myself and didn't find the `View` property, because `contactDetails` itself is of type `View<_>`, but it does have a `Doc(...)` method)