### PR TITLE
Improvements in examples for View in master branch

### DIFF
--- a/v4.x/fsharp/ui.md
+++ b/v4.x/fsharp/ui.md
@@ -1295,6 +1295,7 @@ Once you have created a View to represent your dynamic content, here are the var
             |> Doc.Concat
         )
     div [] [
+        Doc.Input [] varTxt
         text "You entered the following words:"
         ul [] [ vWords ]
     ]

--- a/v4.x/fsharp/ui.md
+++ b/v4.x/fsharp/ui.md
@@ -1277,7 +1277,7 @@ Once you have created a View to represent your dynamic content, here are the var
         |> View.Map String.length
         |> View.Map (fun l -> sprintf "You entered %i characters." l)
     div [] [
-        Doc.Input [] varName
+        Doc.Input [] varTxt
         textView vLength
     ]
     ```


### PR DESCRIPTION
This PR addresses issues [27](https://github.com/dotnet-websharper/docs/issues/27) and [28](https://github.com/dotnet-websharper/docs/issues/28) in two separate commits for the branch master.

The first one is related to a typo in one of the examples, and the second improves one example related to `Doc.BindView`.