### PR TITLE
Improvements in examples for View in main branch

### DIFF
--- a/ui/views.md
+++ b/ui/views.md
@@ -117,7 +117,7 @@ let vLength =
     |> View.Map String.length
     |> View.Map (fun l -> sprintf "You entered %i characters." l)
 div [] [
-    Doc.Input [] varName
+    Doc.Input [] varTxt
     textView vLength
 ]
 ```

--- a/ui/views.md
+++ b/ui/views.md
@@ -135,10 +135,11 @@ let vWords =
     |> View.Map (fun s -> s.Split(' '))
     |> Doc.BindView (fun words ->
         words
-        |> Array.map (fun w -> li [] [text w] :> Doc)
+        |> Array.map (fun w -> li [] [text w])
         |> Doc.Concat
     )
 div [] [
+    Doc.InputType.Text [] varTxt
     text "You entered the following words:"
     ul [] [ vWords ]
 ]


### PR DESCRIPTION
This PR addresses issues [27](https://github.com/dotnet-websharper/docs/issues/27) and [28](https://github.com/dotnet-websharper/docs/issues/28) in two separate commits for the branch main.

The first one is related to a typo in one of the examples, and the second improves one example related to `Doc.BindView`.