### PR TITLE
Fix typo related to View.ConstAsync

### DIFF
--- a/content/ui/reactive.md
+++ b/content/ui/reactive.md
@@ -171,7 +171,7 @@ You can create Views using the following functions and combinators from the `Vie
     // [[v]] = 42
     ```
 
-* `View.ConstAnyc` is similar to `Const`, but is initialized asynchronously. Until the async returns, the resulting View is uninitialized.
+* `View.ConstAsync` is similar to `Const`, but is initialized asynchronously. Until the async returns, the resulting View is uninitialized.
 
 * <a name="view-map"></a>`View.Map` takes an existing View and maps its value through a function.
 


### PR DESCRIPTION
## Description:

Fix typo at the file `content/ui/reactive.md` related to the `View.ConstAsync` presentation.

From the source code, we can check that the function is really called [View.ConstAsync](https://github.com/dotnet-websharper/ui/blob/master/WebSharper.UI/Reactive.fs#L422).